### PR TITLE
Timeout bei nicht verfügbaren Kanälen abfangen

### DIFF
--- a/freq_collect.sh
+++ b/freq_collect.sh
@@ -14,12 +14,8 @@ for i in "${!FREQUENCIES[@]}"; do
     fi
     timeout 5 dvbtune -f ${FREQUENCIES[$i]} -s 6950 -qam 256 > /dev/null 2>&1
     SNOOP_RESULT=`timeout 10 dvbsnoop -s bandwidth 8190 -n 3500 -hideproginfo`
-    # if [ $? -ne 0 ]; then
-    #     echo "Error during dvb snoop"
-    #     exit 1
-    # fi
-    BW=`echo ${SNOOP_RESULT} | awk -F: 'END { print $NF }' | sed 's/^[ \t]*//' | awk '{print $1}'`
-    if [ ${BW} != '15)' ]; then
+    if [ $? -eq 0 ]; then
+        BW=`echo ${SNOOP_RESULT} | awk -F: 'END { print $NF }' | sed 's/^[ \t]*/
         echo "Freq: ${FREQUENCIES[$i]} Measured: ${BW} kbit/s"
         rrdtool update ${BASE_DIR}/${FREQUENCIES[$i]}.rrd N:${BW}
     fi

--- a/freq_collect.sh
+++ b/freq_collect.sh
@@ -15,7 +15,7 @@ for i in "${!FREQUENCIES[@]}"; do
     timeout 5 dvbtune -f ${FREQUENCIES[$i]} -s 6950 -qam 256 > /dev/null 2>&1
     SNOOP_RESULT=`timeout 10 dvbsnoop -s bandwidth 8190 -n 3500 -hideproginfo`
     if [ $? -eq 0 ]; then
-        BW=`echo ${SNOOP_RESULT} | awk -F: 'END { print $NF }' | sed 's/^[ \t]*/
+        BW=`echo ${SNOOP_RESULT} | awk -F: 'END { print $NF }' | sed 's/^[ \t]*//' | awk '{print $1}'`
         echo "Freq: ${FREQUENCIES[$i]} Measured: ${BW} kbit/s"
         rrdtool update ${BASE_DIR}/${FREQUENCIES[$i]}.rrd N:${BW}
     fi

--- a/freq_collect.sh
+++ b/freq_collect.sh
@@ -13,13 +13,15 @@ for i in "${!FREQUENCIES[@]}"; do
         kill -9 ${PID}
     fi
     timeout 5 dvbtune -f ${FREQUENCIES[$i]} -s 6950 -qam 256 > /dev/null 2>&1
-    SNOOP_RESULT=`dvbsnoop -s bandwidth 8190 -n 3500 -hideproginfo`
-    if [ $? -ne 0 ]; then
-        echo "Error during dvb snoop"
-        exit 1
-    fi
+    SNOOP_RESULT=`timeout 10 dvbsnoop -s bandwidth 8190 -n 3500 -hideproginfo`
+    # if [ $? -ne 0 ]; then
+    #     echo "Error during dvb snoop"
+    #     exit 1
+    # fi
     BW=`echo ${SNOOP_RESULT} | awk -F: 'END { print $NF }' | sed 's/^[ \t]*//' | awk '{print $1}'`
-    echo "Freq: ${FREQUENCIES[$i]} Measured: ${BW} kbit/s"
-    rrdtool update ${BASE_DIR}/${FREQUENCIES[$i]}.rrd N:${BW}
+    if [ ${BW} != '15)' ]; then
+        echo "Freq: ${FREQUENCIES[$i]} Measured: ${BW} kbit/s"
+        rrdtool update ${BASE_DIR}/${FREQUENCIES[$i]}.rrd N:${BW}
+    fi
 done
 echo 0 > /sys/module/dvb_core/parameters/dvb_powerdown_on_sleep


### PR DESCRIPTION
Bei nicht verfügbaren Kanälen bricht das Script komplett ab und weitere Kanäle werden nicht mehr gemessen. Als Workaround wurde die Abbruchbedingung auskommentiert und die Übergabe von rrdtool erfolgt nur wenn dvbsnoop nicht auf einen Timeout läuft.
